### PR TITLE
feat: press shortcut key to exit break overlay

### DIFF
--- a/Modules/UI/Overlays/BreakOverlayView.swift
+++ b/Modules/UI/Overlays/BreakOverlayView.swift
@@ -73,6 +73,10 @@ struct BreakOverlayView: View {
                 }
                 .buttonStyle(PlainButtonStyle())
                 .keyboardShortcut(.cancelAction)
+
+                Text("Press Esc or Space to skip")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.white.opacity(0.7))
             }
             .padding(60)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)


### PR DESCRIPTION
Closes #2 
Pressing Esc or Space during the break overlay screen skips the break

<img width="396" height="333" alt="image" src="https://github.com/user-attachments/assets/9899dc4b-1b8b-428a-9de9-eb31c2a4cde3" />
